### PR TITLE
Aumentando a precisão da pesquisa por vagas

### DIFF
--- a/themes/backendbrasil/assets/js/jobs.js
+++ b/themes/backendbrasil/assets/js/jobs.js
@@ -1,285 +1,138 @@
-const generateLabels = labels => {
-  labels = Array.isArray(labels) ? labels : [labels]
+const globals = {
+  issuesPage: 1
+};
 
-  labels = labels.filter(label => label.length)
+const DOM = {
+  stateSelect: $("#state"),
+  keywordInput: $("#keyword"),
+  clearFilter: $("#clearFilter"),
+  moreJobs: $("#loadMoreJobs"),
+  jobsList: $("#jobsListingWrapper")
+};
 
-  labels = labels.map(label => `<li>${label}</li>`)
-  labels = labels.join('')
+const getJobs = filter => {
+  const url = "https://api.github.com/repos/backend-br/vagas/issues";
 
-  if (!labels.length) {
-    return ''
-  }
+  $.getJSON(url, { page: globals.issuesPage++ }, data => {
+    data
+      .map(issue => ({
+        url: issue.html_url,
+        title: getTitle(issue.title),
+        location: getLocation(issue.title),
+        labels: issue.labels.map(label => label.name),
+        id: issue.id
+      }))
+      .filter(issue => !$(`article[data-id='${issue.id}']`).length)
+      .forEach(issue => {
+        DOM.jobsList.append(generateJob(issue));
+      });
 
-  return `
-    <ul class="jobs--flags">
-      ${labels}
-    </ul>
-  `
-}
+    if (!data.length) {
+      DOM.moreJobs.html(DOM.moreJobs.attr("data-is-empty"));
+      DOM.moreJobs.attr("disabled", true);
+    }
 
-const generateLocation = location => location && location.length ? `
-  <p>
-    <span class="fas fa-map"></span>
-    <span>${location}</span>
-  </p>
-` : ''
+    if (filter) {
+      filter();
+    }
+  });
+};
 
-const getLocation = title => {
-  const regex = /^(?:\[)(.*?)(?:\])/g
-
-  const result = title.match(regex)
-
-  if (Array.isArray(result) && result.length) {
-    return result.shift().replace(/\[|\]/g, '')
-  }
-
-  return ''
-}
-
-const jobTitle = title => title.slice ? title.slice(0, 60) : title;
-
-const generateJob = ({ id, url, title, labels, location }) => `
+// Generators
+const generateJob = ({ id, labels, location, title, url }) => `
   <article 
     class="
       jobs--listing-item 
-      no-grow 
-      no-shrink 
-      tile 
-      is-flex-one-quarter-desktop
-      is-flex-one-third-mobile
-      is-flex-full
-    "
+      no-grow no-shrink tile 
+      is-flex-one-quarter-desktop 
+      is-flex-one-third-mobile 
+      is-flex-full"
 
     data-id="${id}"
-    data-labels="${labels.filter(label => label.length).join(',')}"
+    data-labels="${labels}"
     data-location="${location}"
-    data-title="${title.replace(/^\[(.*?)\]\s?/g, '')}"
+    data-title="${title}"
   >
     <a href="${url}" target="_blank">
-      <h4 class="is-size-5">${jobTitle(title.replace(/^\[(.*?)\]\s?/g, ''))}</h4>
-
+      <h4 class="is-size-5">${title}</h4>
       ${generateLabels(labels)}
-
       ${generateLocation(location)}
     </a>
-  </article>
-`
+  </article>`;
 
-const jobHideClass = 'jobs--listing-hidden'
-const setClass = job => {
-  job = $(job)
+const generateLabels = labels => {
+  if (!labels) return "";
 
-  if (!job.hasClass(jobHideClass)) {
-    job.addClass(jobHideClass)
-  }
+  return `
+    <ul class="jobs--flags">
+      ${labels.map(label => `<li>${label}</li>`).join("")}
+    </ul>
+  `;
 };
 
-const filterJobs = ({ key, value }) => {
-  if (value === 'clear') {
-    return $(`.jobs--listing-item[data-${key}]`)
-      .removeClass(jobHideClass)
+const generateLocation = location => {
+  if (!location) return "";
+
+  return `
+    <p>
+      <span class="fas fa-map"></span>
+      <span>${location}</span>
+    </p>`;
+};
+
+// Formatters
+const getLocation = location =>
+  Array(location.match(/^(?:\[)(.*?)(?:\])/g))
+    .join("")
+    .replace(/\[|\]/g, "");
+
+const getTitle = title => title.replace(/^\[(.*?)\]\s?/g, "").slice(0, 60);
+
+// Event Handlers
+DOM.stateSelect.on("change", _ => applyFilters());
+DOM.keywordInput.on("input", _ => applyFilters());
+DOM.clearFilter.on("click", _ => clearFilters());
+DOM.moreJobs.on("click", _ => {
+  if (DOM.moreJobs.attr("disabled") != "true") {
+    getJobs(applyFilters);
   }
+});
 
-  $('.jobs--listing-item').forEach(job => {
-    const dataset = job.dataset
+const applyFilters = () => {
+  // XXX: Zepto não dá suporte ao ":selected" e não tem selectedIndex
+  const stateName =
+    DOM.stateSelect[0].options[DOM.stateSelect[0].selectedIndex].text;
+  const stateInitials = DOM.stateSelect.val();
+  const text = DOM.keywordInput.val();
+  let stateFound = true;
 
-    if (
-      !dataset || 
-      !dataset[key] || 
-      !dataset[key].length ||
-      typeof dataset[key] !== 'string'
-    ) {
-      return setClass(job)
+  DOM.jobsList.find(".jobs--listing-item").forEach(job => {
+    const keys = ["labels", "location", "title"];
+    const textFound = keys
+      .map(key => new RegExp(text, "gi").test(job.dataset[key]))
+      .some(x => x);
+
+    if (stateInitials != "clear") {
+      stateFound = new RegExp(
+        `\\b${stateName}\\b|\\b${stateInitials}\\b`,
+        "gi"
+      ).test(job.dataset["location"]);
     }
 
-    const found = dataset[key]
-      .match(new RegExp(value, 'gi'))
-
-    if (!found || !found.length) {
-      return setClass(job)
+    if (stateFound && textFound) {
+      return $(job).removeClass("jobs--listing-hidden");
     }
 
-    $(job).removeClass('jobs--listing-hidden')
-  })
-}
+    $(job).addClass("jobs--listing-hidden");
+  });
+};
 
-const getPaginators = link => {
-  const result = { next: false, last: false }
+const clearFilters = () => {
+  DOM.stateSelect.val("clear");
+  DOM.keywordInput.val("");
+  DOM.jobsList
+    .find(".jobs--listing-hidden")
+    .removeClass("jobs--listing-hidden");
+};
 
-  if (!link) {
-    return result
-  }
-
-  const links = link.split(',')
-  const linkRegex = /^\s?<(.*?)>/g
-  const relRegex = /"([a-z]{4})"/g
-
-  links.forEach(it => {
-    let url = it.match(linkRegex)
-    let rel = it.match(relRegex)
-
-    if (url && url.length) {
-      url = url.shift().replace(/<|>|/g, '')
-    }
-
-    if (rel && rel.length) {
-      rel = rel.shift().replace(/"+/g, '')
-    }
-
-    if (rel === 'next') {
-      result.next = url
-    } else {
-      result.last = url
-    }
-  })
-
-  return result
-}
-
-const loadIssues = (url, cb) => $.getJSON(
-  url,
-  (data, status, xhr) => {
-    window.data = xhr
-    const issues = $
-      .map(data, issue => ({
-        url: issue.html_url,
-        title: issue.title,
-        location: getLocation(issue.title),
-        labels: $.map(issue.labels, label => label.name),
-        id: issue.id
-      }))
-      .filter(issue => !$(`article[data-issue-id='${issue.id}']`).length)
-      .map(generateJob)
-      
-    if (issues.length) {
-      $('#jobsListingWrapper').append(issues.join(''))
-    }
-
-    const { next, last } = getPaginators(xhr.getResponseHeader('Link'))
-    const loadBtn = $('#loadMoreJobs')
-    const currentNextUrl = loadBtn.attr('data-next')
-
-    if (cb) {
-      cb()
-    }
-
-    if (
-      (!next && currentNextUrl.length) ||
-      !issues.length ||
-      next === url ||
-      next === currentNextUrl
-    ) {
-      loadBtn.html(loadBtn.attr('data-is-empty'))
-      loadBtn.attr('disabled', true)
-      return
-    }
-
-    loadBtn.attr('data-next', next)
-  }
-)
-
-document.addEventListener('DOMContentLoaded', () => {
-  if (!$('#state').length) {
-    return
-  }
-
-  const githubIssuesUrl = 'https://api.github.com/repos/backend-br/vagas/issues'
-  loadIssues(githubIssuesUrl)
-  const toWatch = [
-    {
-      htmlId: 'state',
-      filterKey: ['location'],
-      clearValue: 'clear'
-    },
-    {
-      htmlId: 'language',
-      filterKey: ['labels'],
-      clearValue: 'clear'
-    }
-  ]
-
-  const applySelectFilter = item => {
-    const value = $(`#${item.htmlId}`).val()
-    
-    if(value) {
-      item
-        .filterKey
-        .forEach(
-          key => filterJobs({ key, value })
-        )
-    }
-  };
-
-  const applyTextFilter = () => {
-    const value = $('#keyword').val()
-
-    $('.jobs--listing-item').forEach(job => {
-      const filterKeys = ['labels', 'location', 'title']
-      const dataset = job.dataset
-      const keys = filterKeys.map(k => k);
-
-      if (!dataset) {
-        return setClass(job)
-      }
-
-      let keep = false
-
-      while (keys.length) {
-        const key = keys.shift()
-
-        if (dataset[key]) {
-          keep = true
-          break;
-        }
-      }
-
-      if (!keep) {
-        return setClass(job)
-      }
-
-      let show = false
-
-      while (filterKeys.length) {
-        const key = filterKeys.shift()
-        const found = dataset[key]
-          .match(new RegExp(value, 'gi'))
-
-        if (found && found.length) {
-          show = true
-          break;
-        }
-      }
-
-      if (!show) {
-        return setClass(job)
-      }
-
-      $(job).removeClass('jobs--listing-hidden')
-    })
-  };
-
-  toWatch.forEach(item => {
-    $(`#${item.htmlId}`).on('change', e => applySelectFilter(item))
-  })
-
-  $('#keyword').on('input', e => applyTextFilter())
-
-  $('#clearFilter').on('click', e => {
-    $('.jobs--listing-hidden') 
-      .removeClass('jobs--listing-hidden')
-
-    toWatch
-      .forEach(
-        item => $(`#${item.htmlId}`).val(item.clearValue || '')
-      )
-  })
-
-  $('#loadMoreJobs').on('click', e => {
-    const loadBtn = $('#loadMoreJobs')
-    const currentNextUrl = loadBtn.attr('data-next')
-    loadIssues(currentNextUrl, () => {
-      applyTextFilter()
-      toWatch.forEach(applySelectFilter)
-    })
-  })
-})
+//getJobs();

--- a/themes/backendbrasil/assets/js/jobs.js
+++ b/themes/backendbrasil/assets/js/jobs.js
@@ -135,4 +135,4 @@ const clearFilters = () => {
     .removeClass("jobs--listing-hidden");
 };
 
-//getJobs();
+getJobs();


### PR DESCRIPTION
Reescrevi um pouco do último código de pesquisa, agora ele tanto pesquisa pela sigla como por extenso e a pesquisa por texto não remove o filtro de estado.
Funcionará bem até a chegada de uma api própria.

O que foi alterado:
- Ao escolher o estado ele pesquisa por extenso ou sigla. eg. "SP" ou "São Paulo", se o `location` tiver qualquer um dos valores ele vai mostrar, usando **word boundary** (e**SP**aço não será selecionado), mas "SP/RJ" aparecerá tanto para Rio de Janeiro como São Paulo.
- Ao digitar no campo de filtro de texto, o filtro de estado continuará funcionando.
Eg. selecionar SP mostrará apenas vagas de São Paulo, e se digitar "analista", aparecerão apenas as vagas de analista em São Paulo, não mais todas as vagas de analista.

O que não foi alterado:
- Ao clicar em "carregar mais" se tiver filtro e o mesmo remover todos os novos valores, nada será adicionado a lista. Tentei fazer essa verificação e fazer uma nova pesquisa por novas issues caso todas sejam removidas, mas não consegui.